### PR TITLE
Pin XML update for Aseprite 1.2.11

### DIFF
--- a/theme.xml
+++ b/theme.xml
@@ -636,6 +636,15 @@
         <style id="recent_file_detail" border="2" border-left="0" extends="recent_file">
             <text color="disabled" align="left" x="2" />
         </style>
+	<style id="recent_file_pin">
+            <background color="background" />
+            <background color="menuitem_hot_face" state="mouse" />
+            <background color="listitem_selected_face" state="selected" />
+            <icon part="unpinned" align="center middle" color="text" />
+            <icon part="unpinned" align="center middle" color="listitem_selected_text" state="selected" />
+            <icon part="pinned" align="center middle" color="text" state="focus" />
+            <icon part="pinned" align="center middle" color="listitem_selected_text" state="focus selected" />
+        </style>
         <style id="news_item" border="2">
             <background color="background" />
             <background color="menuitem_hot_face" state="mouse" />


### PR DESCRIPTION
Quick update to make pins visible in recent files based on the most recent update
[https://blog.aseprite.org/2019/05/11/aseprite-v1211/](https://blog.aseprite.org/2019/05/11/aseprite-v1211/)
